### PR TITLE
System Spec の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,8 +56,6 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
-  # Easy installation and use of web drivers to run system tests with browsers
-  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,10 +242,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.1.3)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -283,7 +279,6 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
-  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -5,8 +5,8 @@ class WelcomeController < ApplicationController
     return if params[:url].blank?
 
     @url = params[:url]
-    sample = Sample.new(url: @url)
-    @result = sample.issues
+    sample = Sample.new
+    @result = sample.issues(@url)
     @message = sample.message if sample.message.present?
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 
 require 'rspec/rails'
+require 'capybara/rails'
 require 'capybara/rspec'
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
@@ -25,7 +26,7 @@ end
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :rack_test
   end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/system/sample_spec.rb
+++ b/spec/system/sample_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Sample', type: :system do
+  # FIXME: GitHub API は 1時間 60回までしか使えない制限があるため、CircleCI などでコケる可能性がある
   it 'Get Issues rails/rails' do
     visit root_path
     fill_in 'url', with: 'rails/rails'

--- a/spec/system/sample_spec.rb
+++ b/spec/system/sample_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+describe 'Sample', type: :system do
+  it 'Get Issues rails/rails' do
+    visit root_path
+    fill_in 'url', with: 'rails/rails'
+    click_button 'Search'
+    expect(page).to have_content 'rails/rails の検索結果'
+  end
+end


### PR DESCRIPTION
## TODO

- [x] System Spec を導入する
- [x] テストが通ること

System Spec とはいえ、今回の要件では js を使っていないので `driven_by :rack_test` の設定で対応した。

参考:
[rspec-rails 3.7の新機能！System Specを使ってみた - Qiita](https://qiita.com/jnchito/items/c7e6e7abf83598a6516d)