### PR TITLE
Heroku の本番環境で動かないバグの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
+  # Easy installation and use of web drivers to run system tests with browsers
+  gem 'webdrivers'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.1.3)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -279,6 +283,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  webdrivers
   webpacker (~> 4.0)
 
 RUBY VERSION

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
-rm -f /myapp/tmp/pids/server.pid
+rm -f /octrouble-api/tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
```
Starting process with command `rails server -b 0.0.0.0`
2019-11-05T14:51:58.737242+00:00 heroku[web.1]: Process exited with status 1
2019-11-05T14:51:58.820915+00:00 heroku[web.1]: State changed from starting to crashed
2019-11-05T14:51:58.657718+00:00 app[web.1]: => Booting Puma
2019-11-05T14:51:58.657747+00:00 app[web.1]: => Rails 6.0.0 application starting in production
2019-11-05T14:51:58.657769+00:00 app[web.1]: => Run `rails server --help` for more startup options
2019-11-05T14:51:58.659438+00:00 app[web.1]: A server is already running. Check /octrouble-api/tmp/pids/server.pid.
2019-11-05T14:51:58.659521+00:00 app[web.1]: Exiting
2019-11-05T14:52:00.096245+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=octrouble-api.herokuapp.com request_id=40c61cc3-8e80-4fc0-8056-224c841cd70d fwd="126.7.35.52" dyno= connect= service= status=503 bytes= protocol=https
2019-11-05T14:52:00.107738+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/?url=rails%2Frails" host=octrouble-api.herokuapp.com request_id=2dfaa163-89f3-4a1d-a942-39b00ab7c959 fwd="126.7.35.52" dyno= connect= service= status=503 bytes= protocol=https
2019-11-05T14:52:01.113241+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=octrouble-api.herokuapp.com request_id=85733c71-38b5-4182-859c-deb76f3b4869 fwd="126.7.35.52" dyno= connect= service= status=503 bytes= protocol=https
```

見たところ `/octrouble-api/tmp/pids/server.pid.` が原因のエラーのよう。

entrypoint.sh を見たら、 `rm -f /myapp/tmp/pids/server.pid` になっていたので、 `octrouble-api` に修正する。